### PR TITLE
カテゴリー作成ページのレイアウト修正

### DIFF
--- a/app/components/common/CustomInput.tsx
+++ b/app/components/common/CustomInput.tsx
@@ -37,7 +37,6 @@ const CustomInput: React.FC<TProps> = ({
       onChange={onChange}
       size="small"
       fullWidth
-      margin="normal"
     />
   );
 };

--- a/app/components/post/PostForm.tsx
+++ b/app/components/post/PostForm.tsx
@@ -74,7 +74,7 @@ const PostForm: React.FC<TProps> = ({
         type="submit"
         variant="contained"
         color="primary"
-        sx={{ mt: 3, mb: 2, px: 15 }}
+        sx={{ mt: 3, mb: 2, px: { xs: 10, md: 15 } }}
         disabled={loading}
       >
         {loading ? "作成中..." : "Post を作成"}

--- a/app/components/post/PostForm.tsx
+++ b/app/components/post/PostForm.tsx
@@ -54,16 +54,9 @@ const PostForm: React.FC<TProps> = ({
           flexDirection={"column"}
           alignItems="left"
           width="100%"
-          mb={2}
+          my={2}
         >
-          <Typography variant="body1" sx={{ mr: 2 }}>
-            {categories[index]?.name}
-          </Typography>
-          <input
-            type="hidden"
-            {...register(`descriptions.${index}.categoryId`)} // categoryId を hidden フィールドで送信
-            value={field.id}
-          />
+          <Typography variant="body1">{categories[index]?.name}</Typography>
           <CustomInput
             id={`descriptions.${index}.content`}
             label={`説明 ${index + 1}`}
@@ -72,15 +65,18 @@ const PostForm: React.FC<TProps> = ({
             required
             errors={errors}
           />
+          <input
+            type="hidden"
+            {...register(`descriptions.${index}.categoryId`)} // categoryId を hidden フィールドで送信
+            value={field.id}
+          />
         </Box>
       ))}
-
       <Button
         type="submit"
-        fullWidth
         variant="contained"
         color="primary"
-        sx={{ mt: 3, mb: 2 }}
+        sx={{ mt: 3, mb: 2, px: 15 }}
         disabled={loading}
       >
         {loading ? "作成中..." : "Post を作成"}

--- a/app/components/post/PostForm.tsx
+++ b/app/components/post/PostForm.tsx
@@ -13,6 +13,7 @@ type TProps = {
   loading: boolean;
   categories: Category[];
 };
+
 const PostForm: React.FC<TProps> = ({
   onSubmit,
   register,
@@ -34,16 +35,15 @@ const PostForm: React.FC<TProps> = ({
       <Typography variant="h4" component="h1" mb={2} gutterBottom>
         Post の作成
       </Typography>
-      <Box width="100%" my={2}>
-        <CustomInput
-          id="title"
-          label="タイトル"
-          register={register}
-          disabled={loading}
-          required
-          errors={errors}
-        />
-      </Box>
+      <CustomInput
+        id="title"
+        label="タイトル"
+        register={register}
+        disabled={loading}
+        required
+        errors={errors}
+        sx={{ my: 2 }}
+      />
       {/* 各カテゴリに対応する説明フィールド */}
       {categories.map((field, index) => (
         <Box

--- a/app/components/post/PostForm.tsx
+++ b/app/components/post/PostForm.tsx
@@ -29,6 +29,7 @@ const PostForm: React.FC<TProps> = ({
       flexDirection="column"
       alignItems="center"
       justifyContent="center"
+      mx={{ xs: 2, md: 15 }}
       mt={5}
       onSubmit={onSubmit}
     >
@@ -50,7 +51,8 @@ const PostForm: React.FC<TProps> = ({
         <Box
           key={field.id}
           display="flex"
-          alignItems="center"
+          flexDirection={"column"}
+          alignItems="left"
           width="100%"
           mb={2}
         >

--- a/app/components/post/PostForm.tsx
+++ b/app/components/post/PostForm.tsx
@@ -6,7 +6,6 @@ type Category = {
   id: number;
   name: string;
 };
-
 type TProps = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
   register: UseFormRegister<FieldValues>;
@@ -14,7 +13,6 @@ type TProps = {
   loading: boolean;
   categories: Category[];
 };
-
 const PostForm: React.FC<TProps> = ({
   onSubmit,
   register,
@@ -33,19 +31,19 @@ const PostForm: React.FC<TProps> = ({
       mt={5}
       onSubmit={onSubmit}
     >
-      <Typography variant="h4" component="h1" gutterBottom>
+      <Typography variant="h4" component="h1" mb={2} gutterBottom>
         Post の作成
       </Typography>
-
-      <CustomInput
-        id="title"
-        label="タイトル"
-        register={register}
-        disabled={loading}
-        required
-        errors={errors}
-      />
-
+      <Box width="100%" my={2}>
+        <CustomInput
+          id="title"
+          label="タイトル"
+          register={register}
+          disabled={loading}
+          required
+          errors={errors}
+        />
+      </Box>
       {/* 各カテゴリに対応する説明フィールド */}
       {categories.map((field, index) => (
         <Box


### PR DESCRIPTION
## やったこと
入力フィールド間の余白調整や、作成ボタンの大きさ調整レスポンシブ対応を行いました。あまりにも地味で申し訳ないです💦
## スクリーンショット
![スクリーンショット 2024-09-07 095740](https://github.com/user-attachments/assets/3a6531c2-4554-490b-b380-e07e4d91164f)
![スクリーンショット 2024-09-07 095823](https://github.com/user-attachments/assets/08871ed2-2d46-43ba-b69d-7e3a2d02b2a4)
![スクリーンショット 2024-09-07 095835](https://github.com/user-attachments/assets/b27c368d-08e2-4c6d-9102-677fcf4d1d2f)
