### PR TITLE
カテゴリー作成ページを修正

### DIFF
--- a/app/components/category/CategoryForm.tsx
+++ b/app/components/category/CategoryForm.tsx
@@ -43,7 +43,7 @@ const CategoryForm: React.FC<TProps> = ({
         mt={5}
         onSubmit={onSubmit}
       >
-        <Typography variant="h4" component="h1" gutterBottom>
+        <Typography variant="h5" component="h1" gutterBottom>
           カテゴリーを追加
         </Typography>
         {fields.map((field, index) => (

--- a/app/components/category/CategoryForm.tsx
+++ b/app/components/category/CategoryForm.tsx
@@ -44,7 +44,7 @@ const CategoryForm: React.FC<TProps> = ({
         onSubmit={onSubmit}
       >
         <Typography variant="h5" component="h1" gutterBottom>
-          カテゴリーを追加
+          カテゴリーを作成
         </Typography>
         {fields.map((field, index) => (
           <Box

--- a/app/components/category/CategoryForm.tsx
+++ b/app/components/category/CategoryForm.tsx
@@ -52,7 +52,7 @@ const CategoryForm: React.FC<TProps> = ({
             display="flex"
             alignItems="center"
             width="100%"
-            sx={{ my: 2 }}
+            my={2}
           >
             <CustomInput
               id={`categories.${index}.name`}

--- a/app/components/category/CategoryForm.tsx
+++ b/app/components/category/CategoryForm.tsx
@@ -75,7 +75,7 @@ const CategoryForm: React.FC<TProps> = ({
           type="button"
           fullWidth
           variant="outlined"
-          color="secondary"
+          color="primary"
           onClick={() => append({ name: "" })}
           sx={{ mt: 3 }}
           disabled={loading}

--- a/app/components/category/CategoryForm.tsx
+++ b/app/components/category/CategoryForm.tsx
@@ -46,9 +46,14 @@ const CategoryForm: React.FC<TProps> = ({
         <Typography variant="h4" component="h1" gutterBottom>
           カテゴリーを追加
         </Typography>
-
         {fields.map((field, index) => (
-          <Box key={field.id} display="flex" alignItems="center" width="100%">
+          <Box
+            key={field.id}
+            display="flex"
+            alignItems="center"
+            width="100%"
+            sx={{ my: 2 }}
+          >
             <CustomInput
               id={`categories.${index}.name`}
               label={`カテゴリー ${index + 1}`}
@@ -66,7 +71,6 @@ const CategoryForm: React.FC<TProps> = ({
             </IconButton>
           </Box>
         ))}
-
         <Button
           type="button"
           fullWidth
@@ -79,7 +83,6 @@ const CategoryForm: React.FC<TProps> = ({
         >
           カテゴリーを追加
         </Button>
-
         <Button
           type="submit"
           fullWidth

--- a/app/components/category/CategoryForm.tsx
+++ b/app/components/category/CategoryForm.tsx
@@ -85,12 +85,11 @@ const CategoryForm: React.FC<TProps> = ({
         </Button>
         <Button
           type="submit"
-          fullWidth
           variant="contained"
           color="primary"
-          sx={{ mt: 3, mb: 2 }}
+          sx={{ mt: 3, mb: 2, px: { xs: 10, mt: 15 } }}
         >
-          {loading ? "追加中" : "追加"}
+          {loading ? "作成中" : "カテゴリーを作成"}
         </Button>
       </Box>
     </Container>

--- a/app/components/category/CategoryForm.tsx
+++ b/app/components/category/CategoryForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-hook-form";
 import CustomInput from "../common/CustomInput";
 import AddIcon from "@mui/icons-material/Add";
-import RemoveIcon from "@mui/icons-material/Remove";
+import DeleteIcon from "@mui/icons-material/Delete";
 
 type TProps = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
@@ -62,7 +62,7 @@ const CategoryForm: React.FC<TProps> = ({
               disabled={loading}
               aria-label="remove"
             >
-              <RemoveIcon />
+              <DeleteIcon />
             </IconButton>
           </Box>
         ))}

--- a/app/components/group/GroupForm.tsx
+++ b/app/components/group/GroupForm.tsx
@@ -26,8 +26,8 @@ const GroupForm: React.FC<TProps> = ({
         mt={5}
         onSubmit={onSubmit}
       >
-        <Typography variant="h4" component="h1" gutterBottom>
-          追加
+        <Typography variant="h5" component="h1" gutterBottom>
+          グループを作成
         </Typography>
         <CustomInput
           id="groupName"

--- a/app/components/post/PostForm.tsx
+++ b/app/components/post/PostForm.tsx
@@ -32,7 +32,7 @@ const PostForm: React.FC<TProps> = ({
       mt={5}
       onSubmit={onSubmit}
     >
-      <Typography variant="h4" component="h1" mb={2} gutterBottom>
+      <Typography variant="h5" component="h1" mb={2} gutterBottom>
         Post の作成
       </Typography>
       <CustomInput


### PR DESCRIPTION
## やったこと
入力フィールド間の余白調整。カテゴリー追加ボタンの色を変更。作成ボタンの大きさ調整。消去アイコンをゴミ箱に変更。
## スクリーンショット　文字小さくする前
![image](https://github.com/user-attachments/assets/b1ba11ed-e6fa-4d28-bf3f-60cde312a365)
![image](https://github.com/user-attachments/assets/cbcf7658-4a69-4555-aa2b-f58716c948ca)
## スクリーンショット　文字小さくした後
![image](https://github.com/user-attachments/assets/1721821a-3a7d-45dd-8aaf-bfa312cf0283)
![image](https://github.com/user-attachments/assets/51a958d1-f480-4a76-99fd-34cd493694ff)

