### PR TITLE
グループ作成ページのレイアウト修正。

### DIFF
--- a/app/components/common/CustomInput.tsx
+++ b/app/components/common/CustomInput.tsx
@@ -1,4 +1,4 @@
-import { TextField } from "@mui/material";
+import { SxProps, TextField } from "@mui/material";
 import { FieldValues, UseFormRegister } from "react-hook-form";
 import { ComponentProps } from "react";
 
@@ -11,6 +11,7 @@ type TProps = ComponentProps<typeof TextField> & {
   register: UseFormRegister<FieldValues>;
   errors: any;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  sx?: SxProps;
 };
 
 const CustomInput: React.FC<TProps> = ({
@@ -23,6 +24,7 @@ const CustomInput: React.FC<TProps> = ({
   register,
   errors,
   onChange,
+  sx,
 }) => {
   return (
     <TextField
@@ -37,6 +39,7 @@ const CustomInput: React.FC<TProps> = ({
       onChange={onChange}
       size="small"
       fullWidth
+      sx={sx}
     />
   );
 };

--- a/app/components/group/GroupForm.tsx
+++ b/app/components/group/GroupForm.tsx
@@ -39,12 +39,11 @@ const GroupForm: React.FC<TProps> = ({
         />
         <Button
           type="submit"
-          fullWidth
           variant="contained"
           color="primary"
-          sx={{ mt: 3, mb: 2 }}
+          sx={{ mt: 3, mb: 2, px: { xs: 10, mt: 15 } }}
         >
-          {loading ? "追加中" : "追加"}
+          {loading ? "作成中" : "グループを作成"}
         </Button>
       </Box>
     </Container>

--- a/app/components/group/GroupForm.tsx
+++ b/app/components/group/GroupForm.tsx
@@ -29,16 +29,15 @@ const GroupForm: React.FC<TProps> = ({
         <Typography variant="h5" component="h1" gutterBottom>
           グループを作成
         </Typography>
-        <Box my={2} width={"100%"}>
-          <CustomInput
-            id="groupName"
-            label="グループ"
-            disabled={loading}
-            register={register}
-            errors={errors}
-            required
-          />
-        </Box>
+        <CustomInput
+          id="groupName"
+          label="グループ"
+          disabled={loading}
+          register={register}
+          errors={errors}
+          required
+          sx={{ my: 2 }}
+        />
         <Button
           type="submit"
           variant="contained"

--- a/app/components/group/GroupForm.tsx
+++ b/app/components/group/GroupForm.tsx
@@ -29,14 +29,16 @@ const GroupForm: React.FC<TProps> = ({
         <Typography variant="h5" component="h1" gutterBottom>
           グループを作成
         </Typography>
-        <CustomInput
-          id="groupName"
-          label="グループ"
-          disabled={loading}
-          register={register}
-          errors={errors}
-          required
-        />
+        <Box my={2} width={"100%"}>
+          <CustomInput
+            id="groupName"
+            label="グループ"
+            disabled={loading}
+            register={register}
+            errors={errors}
+            required
+          />
+        </Box>
         <Button
           type="submit"
           variant="contained"


### PR DESCRIPTION
## やったこと
入力フィールド間の余白を調整し、グループ作成ボタンの文字と大きさを修正しました。
## スクリーンショット
![image](https://github.com/user-attachments/assets/3aeb997a-4926-4d92-a402-c9ff527dba47)
